### PR TITLE
SVG changed to IMG so that they can redirect to socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,16 +110,13 @@
 					</div>
 
 			</div>
-			<div class="marVertAlign">
+			<div class="marVertAlign" >
 				<a href="https://github.com/GlennMathias"  id="github_contact">
+					<img src="./assets/SVG/iconmonstr-github-3.svg" alt="github" style="margin: 5px;">
 				</a>
-					<object data="./assets/SVG/iconmonstr-github-3.svg" style="margin: 5px;" type="image/svg+xml" onclick="console.log('git hub');github_contact.click()">
-				  	</object>
 				<a href="https://www.linkedin.com/in/glenn-mathias-5863371b4/" id="linkedIn_contact">
-				</a>
-					<object onclick="console.log('Linked in');linkedIn_contact.click()" data="./assets/SVG/iconmonstr-linkedin-3.svg" type="image/svg+xml"  style="margin: 5px;" 
-					style="fill:red;width: 24px; height: 24px;">
-				  	</object>
+					<img src="./assets/SVG/iconmonstr-linkedin-3.svg" alt="linkedIn" style="margin: 5px;">
+				</a>					
 			</div>
 		</div>
 


### PR DESCRIPTION
SVG changed to IMG so that GiHub and LinkedIn can redirect to socials.